### PR TITLE
feat: use Textarea as lead field widget

### DIFF
--- a/api_graphql/snapshots/snap_tests.py
+++ b/api_graphql/snapshots/snap_tests.py
@@ -169,3 +169,27 @@ snapshots['test_settings 1'] = {
         }
     }
 }
+
+snapshots['test_all_categories 1'] = {
+    'data': {
+        'allCategories': [
+            {
+                'backgroundColor': '#ECB61C',
+                'id': 1,
+                'name': 'Radio',
+                'textColor': '#000000'
+            }
+        ]
+    }
+}
+
+snapshots['test_category_by_id 1'] = {
+    'data': {
+        'category': {
+            'backgroundColor': '#ECB61C',
+            'id': 1,
+            'name': 'Radio',
+            'textColor': '#000000'
+        }
+    }
+}

--- a/api_graphql/tests.py
+++ b/api_graphql/tests.py
@@ -159,6 +159,36 @@ def test_all_shows(snapshot):
 
 
 @pytest.mark.django_db
+def test_all_categories(snapshot):
+    client = Client(schema)
+    executed = client.execute('''query {
+        allCategories {
+            id,
+            name,
+            textColor,
+            backgroundColor
+        }
+    }''')
+
+    snapshot.assert_match(executed)
+
+
+@pytest.mark.django_db
+def test_category_by_id(snapshot):
+    client = Client(schema)
+    executed = client.execute('''query {
+        category(id:1) {
+            id,
+            name,
+            textColor,
+            backgroundColor
+        }
+    }''')
+
+    snapshot.assert_match(executed)
+
+
+@pytest.mark.django_db
 def test_url_all_shows(client, snapshot):
     response = client.get('/graphql?query=query%20{%20allShows%20{%20id%20}%20}')
 

--- a/data_models/admin.py
+++ b/data_models/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django_summernote.admin import SummernoteModelAdmin
 from solo.admin import SingletonModelAdmin
 from sorl_cropping import ImageCroppingMixin
+from django import forms
 
 from .models import Category, Episode, Post, Settings, Show
 
@@ -67,3 +68,11 @@ class EpisodeAdmin(admin.ModelAdmin):
     list_display = ('title', 'show', 'publish_at')
     list_filter = (ActiveShowFilter, ArchivedShowFilter)
     search_fields = ('title', 'show__name')
+
+    # Set form field for "lead" to Textarea instead of Textinput
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        formfield = super(EpisodeAdmin, self).formfield_for_dbfield(db_field, **kwargs)
+        if db_field.name == 'lead':
+            formfield.widget = forms.Textarea(attrs={'cols': 60, 'rows': 5})
+        return formfield
+

--- a/data_models/admin.py
+++ b/data_models/admin.py
@@ -1,8 +1,8 @@
+from django import forms
 from django.contrib import admin
 from django_summernote.admin import SummernoteModelAdmin
 from solo.admin import SingletonModelAdmin
 from sorl_cropping import ImageCroppingMixin
-from django import forms
 
 from .models import Category, Episode, Post, Settings, Show
 
@@ -75,4 +75,3 @@ class EpisodeAdmin(admin.ModelAdmin):
         if db_field.name == 'lead':
             formfield.widget = forms.Textarea(attrs={'cols': 60, 'rows': 5})
         return formfield
-

--- a/data_models/tests.py
+++ b/data_models/tests.py
@@ -37,6 +37,13 @@ def test_admin_episode(admin_client):
 
 
 @pytest.mark.django_db
+def test_admin_settings(admin_client):
+    response = admin_client.get('/admin/data_models/settings/')
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_admin_post_details(admin_client):
     response = admin_client.get('/admin/data_models/post/2/change/')
 


### PR DESCRIPTION
The "lead" field for episodes can be up to 140 characters long, but the default widget used in Django admin is a single line Textinput field, which makes writing longer texts difficult. 

This PR introduces a custom widget for that specific field in the Django admin.