### PR TITLE
fix: updates link underline color to provide contrast and affordance

### DIFF
--- a/data_models/static/ckeditor/editor.css
+++ b/data_models/static/ckeditor/editor.css
@@ -12,7 +12,7 @@ body {
 a {
     background: transparent !important;
     color: black;
-    text-decoration-color: #ECB61C;
+    text-decoration-color: black;
 }
 
 img {


### PR DESCRIPTION
Updates the editor.css to have black underline instead of the previous RadioRevolt orange color, which has a bad contrast to the background color in articles. 
