### PR TITLE
build: add two apt packages required on clean Ubuntu 19.04 installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ virtualenv -p python3 venv
 ### Install requirements
 
 ```bash
+sudo apt-get install libpq-dev python3-dev zlib1g-dev libjpeg-dev 
 pip install -r requirements.txt
-sudo apt-get install libpq-dev python3-dev
 pip install psycopg2
 ```
 


### PR DESCRIPTION
Adds two packages to the setup script in the README, required for Ubuntu 19.04. Does not break backwards compatibility.