### PR TITLE
Fix/remove episode filter

### DIFF
--- a/api_graphql/utils.py
+++ b/api_graphql/utils.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.utils import timezone
 

--- a/api_graphql/utils.py
+++ b/api_graphql/utils.py
@@ -42,8 +42,4 @@ def get_public_posts(posts):
 def get_public_episodes(episodes):
     return episodes \
         .order_by('-publish_at') \
-        .filter(publish_at__lte=timezone.now()) \
-        .filter(publish_at__gte=timezone.now() - timedelta(days=730))
-    # Hide all episodes that are older than 2 years, because of license rights through TONO.
-    # We are not allowed to make old episodes with music available. In the future we are hopefully
-    # allowed to serve old episodes with music.
+        .filter(publish_at__lte=timezone.now())


### PR DESCRIPTION
The deal with TONO is soon going through and episodes older than two years are allowed to be visible again.